### PR TITLE
Feature display total number of games counter

### DIFF
--- a/src/components/PaginationUI.js
+++ b/src/components/PaginationUI.js
@@ -1,8 +1,6 @@
 import renderGames from '../modules/RenderGames.js';
 import gamesApi from '../modules/GamesAPI.js';
 
-let { pageNumber } = gamesApi;
-
 const renderPagination = () => {
   const mainSection = document.querySelector('#main');
   const paginationContainer = document.createElement('div');
@@ -11,10 +9,10 @@ const renderPagination = () => {
   const btnNext = document.createElement('button');
 
   btnPrevious.classList.add('btn', 'btn-previous');
-  btnPrevious.textContent = '<< Prev';
-  pageNumberLabel.textContent = ` - ${pageNumber >= 0 ? pageNumber + 1 : 1} -`;
+  btnPrevious.textContent = '< prev';
+  pageNumberLabel.textContent = ` - ${gamesApi.pageNumber >= 0 ? gamesApi.pageNumber + 1 : 1} -`;
   btnNext.classList.add('btn', 'btn-next');
-  btnNext.textContent = 'Next >>';
+  btnNext.textContent = 'next >';
   paginationContainer.classList.add('pagination-container');
   paginationContainer.appendChild(btnPrevious);
   paginationContainer.appendChild(pageNumberLabel);
@@ -22,21 +20,33 @@ const renderPagination = () => {
 
   mainSection.appendChild(paginationContainer);
 
+  if (gamesApi.pageNumber <= 0) btnPrevious.disabled = true;
+
   btnNext.addEventListener('click', () => {
     const gameListContainer = document.querySelector('.games-list');
     gameListContainer.innerHTML = '';
-    pageNumber = (pageNumber + 1) < (gamesApi.getNumberOfGames() / 15)
-      ? pageNumber + 1 : gamesApi.getNumberOfGames / 15;
-    pageNumberLabel.textContent = ` - ${pageNumber + 1} -`;
-    renderGames(pageNumber);
+    gamesApi.pageNumber = (gamesApi.pageNumber) < Math.floor(gamesApi.getNumberOfGames() / 15)
+      ? gamesApi.pageNumber + 1 : Math.floor(gamesApi.getNumberOfGames / 15);
+    pageNumberLabel.textContent = ` - ${gamesApi.pageNumber + 1} -`;
+
+    renderGames(gamesApi.pageNumber);
+
+    btnPrevious.disabled = false;
+    if (gamesApi.pageNumber > Math.floor(gamesApi.getNumberOfGames() / 15) - 1) {
+      btnNext.disabled = true;
+    }
   });
 
   btnPrevious.addEventListener('click', () => {
     const gameListContainer = document.querySelector('.games-list');
     gameListContainer.innerHTML = '';
-    pageNumber = pageNumber > 0 ? pageNumber - 1 : 0;
-    pageNumberLabel.textContent = `- ${pageNumber + 1} -`;
-    renderGames(pageNumber);
+    gamesApi.pageNumber = gamesApi.pageNumber > 0 ? gamesApi.pageNumber - 1 : 0;
+    pageNumberLabel.textContent = `- ${gamesApi.pageNumber + 1} -`;
+
+    renderGames(gamesApi.pageNumber);
+
+    btnNext.disabled = false;
+    if (gamesApi.pageNumber <= 0) btnPrevious.disabled = true;
   });
 };
 

--- a/src/components/PaginationUI.js
+++ b/src/components/PaginationUI.js
@@ -1,0 +1,42 @@
+import renderGames from "../modules/RenderGames.js";
+import gamesApi from "../modules/GamesAPI.js";
+
+let pageNumber = gamesApi.pageNumber;
+
+const renderPagination = () => {
+  const mainSection = document.querySelector('#main');
+  const paginationContainer = document.createElement('div');
+  const pageNumberLabel = document.createElement('p');
+  const btnPrevious = document.createElement('button');
+  const btnNext = document.createElement('button');
+
+  btnPrevious.classList.add('btn', 'btn-previous');
+  btnPrevious.textContent = '<< Prev';
+  pageNumberLabel.textContent = ` - ${pageNumber >= 0 ? pageNumber + 1 : 1} -`;
+  btnNext.classList.add('btn', 'btn-next');
+  btnNext.textContent = 'Next >>';
+  paginationContainer.classList.add('pagination-container');
+  paginationContainer.appendChild(btnPrevious);
+  paginationContainer.appendChild(pageNumberLabel);
+  paginationContainer.appendChild(btnNext);
+
+  mainSection.appendChild(paginationContainer);
+
+  btnNext.addEventListener('click', () => {
+    const gameListContainer = document.querySelector('.games-list');
+    gameListContainer.innerHTML = '';
+    pageNumber = (pageNumber + 1) < (gamesApi.getNumberOfGames() / 15) ? pageNumber + 1 : gamesApi.getNumberOfGames / 15;
+    pageNumberLabel.textContent = ` - ${pageNumber + 1} -`;
+    renderGames(pageNumber);
+  });
+
+  btnPrevious.addEventListener('click', () => {
+    const gameListContainer = document.querySelector('.games-list');
+    gameListContainer.innerHTML = '';
+    pageNumber = pageNumber > 0 ? pageNumber - 1 : 0;
+    pageNumberLabel.textContent = `- ${pageNumber + 1} -`;
+    renderGames(pageNumber);
+  });
+}
+
+export default renderPagination;

--- a/src/components/PaginationUI.js
+++ b/src/components/PaginationUI.js
@@ -1,7 +1,7 @@
-import renderGames from "../modules/RenderGames.js";
-import gamesApi from "../modules/GamesAPI.js";
+import renderGames from '../modules/RenderGames.js';
+import gamesApi from '../modules/GamesAPI.js';
 
-let pageNumber = gamesApi.pageNumber;
+let { pageNumber } = gamesApi;
 
 const renderPagination = () => {
   const mainSection = document.querySelector('#main');
@@ -25,7 +25,8 @@ const renderPagination = () => {
   btnNext.addEventListener('click', () => {
     const gameListContainer = document.querySelector('.games-list');
     gameListContainer.innerHTML = '';
-    pageNumber = (pageNumber + 1) < (gamesApi.getNumberOfGames() / 15) ? pageNumber + 1 : gamesApi.getNumberOfGames / 15;
+    pageNumber = (pageNumber + 1) < (gamesApi.getNumberOfGames() / 15)
+      ? pageNumber + 1 : gamesApi.getNumberOfGames / 15;
     pageNumberLabel.textContent = ` - ${pageNumber + 1} -`;
     renderGames(pageNumber);
   });
@@ -37,6 +38,6 @@ const renderPagination = () => {
     pageNumberLabel.textContent = `- ${pageNumber + 1} -`;
     renderGames(pageNumber);
   });
-}
+};
 
 export default renderPagination;

--- a/src/index.html
+++ b/src/index.html
@@ -25,13 +25,12 @@
 
   <!-- Pop Up Comment Section MarkUp (Hidden in initial Load) -->
   <section class="comment-popup-section" id="comment-popup-section">
-  <div class="comment-pop-up-container" id="comment-popup-container">
-    
-  </div>
-</section>
+    <div class="comment-pop-up-container" id="comment-popup-container">
 
+    </div>
+  </section>
 
-<!-- Main HomePage Section -->
+  <!-- Main HomePage Section -->
   <main id="main">
     <h1 class="main-section-title">MMO Games</h1>
     <ul class="games-list" id="games-list">

--- a/src/index.js
+++ b/src/index.js
@@ -2,8 +2,9 @@ import './style.css';
 import ICON from './assets/img/logo.png';
 import gamesApi from './modules/GamesAPI.js';
 import involvementApi from './modules/InvolvementAPI.js';
-import renderGame from './components/GameUI.js';
+import renderGames from './modules/RenderGames.js';
 import renderCommentsPopUp from './components/GameCommentUI.js';
+import renderPagination from './components/PaginationUI.js';
 
 const commentPopUpSectionElement = document.querySelector('#comment-popup-section');
 const mainContainerElement = document.querySelector('#main');
@@ -35,20 +36,20 @@ mainContainer.addEventListener('click', (event) => {
 window.addEventListener('load', async () => {
   commentPopUpSectionElement.style.display = 'none';
   const logoContainer = document.querySelector('.logo-container');
+  const totalGamesLink = document.createElement('a');
+  totalGamesLink.href = '#';
+  const numberOfGames = document.createElement('p');
   const logoIcon = new Image();
-  logoIcon.src = ICON;
-  logoContainer.appendChild(logoIcon);
 
   await gamesApi.getGames();
   await involvementApi.getLikes();
 
-  gamesApi.games.forEach((game) => {
-    if (game.id < 10) {
-      const gameLikes = involvementApi.appLikes.find((item) => item.item_id === game.id);
+  logoIcon.src = ICON;
+  numberOfGames.textContent = `Games(${gamesApi.getNumberOfGames()})`;
+  totalGamesLink.appendChild(numberOfGames);
+  logoContainer.appendChild(logoIcon);
+  logoContainer.appendChild(totalGamesLink);
 
-      game.likes = gameLikes ? gameLikes.likes : 0;
-
-      renderGame(game);
-    }
-  });
+  renderGames(gamesApi.pageNumber);
+  renderPagination();
 });

--- a/src/modules/GamesAPI.js
+++ b/src/modules/GamesAPI.js
@@ -4,11 +4,17 @@ const GAMES_API_BASE_URL = 'https://mmo-games.p.rapidapi.com';
 const HOST = 'mmo-games.p.rapidapi.com';
 
 class GamesApi {
+  static pageNumber = 0;
+
   constructor() {
     this.games = [];
   }
 
+  getNumberOfGames() { return this.games.length }
+
   async getGames() {
+    this.pageNumber = 0;
+
     this.games.push(...await fetch(`${GAMES_API_BASE_URL}/games`,
       {
         headers: {
@@ -19,6 +25,7 @@ class GamesApi {
       .then((response) => response.json())
       .then((data) => data)
       .catch((error) => error));
+
     return this.games;
   }
 

--- a/src/modules/GamesAPI.js
+++ b/src/modules/GamesAPI.js
@@ -10,7 +10,7 @@ class GamesApi {
     this.games = [];
   }
 
-  getNumberOfGames() { return this.games.length }
+  getNumberOfGames() { return this.games.length; }
 
   async getGames() {
     this.pageNumber = 0;

--- a/src/modules/GamesAPI.js
+++ b/src/modules/GamesAPI.js
@@ -3,8 +3,6 @@ import API_KEY from '../../config.js';
 const GAMES_API_BASE_URL = 'https://mmo-games.p.rapidapi.com';
 const HOST = 'mmo-games.p.rapidapi.com';
 
-// export let static pageNumber = 0;
-
 class GamesApi {
   constructor() {
     this.games = [];

--- a/src/modules/GamesAPI.js
+++ b/src/modules/GamesAPI.js
@@ -3,18 +3,17 @@ import API_KEY from '../../config.js';
 const GAMES_API_BASE_URL = 'https://mmo-games.p.rapidapi.com';
 const HOST = 'mmo-games.p.rapidapi.com';
 
-class GamesApi {
-  static pageNumber = 0;
+// export let static pageNumber = 0;
 
+class GamesApi {
   constructor() {
     this.games = [];
+    this.pageNumber = 0;
   }
 
   getNumberOfGames() { return this.games.length; }
 
   async getGames() {
-    this.pageNumber = 0;
-
     this.games.push(...await fetch(`${GAMES_API_BASE_URL}/games`,
       {
         headers: {

--- a/src/modules/RenderGames.js
+++ b/src/modules/RenderGames.js
@@ -1,0 +1,13 @@
+import gamesApi from "./GamesAPI.js";
+import involvementApi from "./InvolvementAPI.js";
+import renderGame from "../components/GameUI.js";
+
+const renderGames = (page) => {
+  gamesApi.games.slice(page * 15, page * 15 + 15).forEach((game) => {
+    const gameLikes = involvementApi.appLikes.find((item) => item.item_id === game.id);
+    game.likes = gameLikes ? gameLikes.likes : 0;
+    renderGame(game);
+  });
+}
+
+export default renderGames;

--- a/src/modules/RenderGames.js
+++ b/src/modules/RenderGames.js
@@ -1,6 +1,6 @@
-import gamesApi from "./GamesAPI.js";
-import involvementApi from "./InvolvementAPI.js";
-import renderGame from "../components/GameUI.js";
+import gamesApi from './GamesAPI.js';
+import involvementApi from './InvolvementAPI.js';
+import renderGame from '../components/GameUI.js';
 
 const renderGames = (page) => {
   gamesApi.games.slice(page * 15, page * 15 + 15).forEach((game) => {
@@ -8,6 +8,6 @@ const renderGames = (page) => {
     game.likes = gameLikes ? gameLikes.likes : 0;
     renderGame(game);
   });
-}
+};
 
 export default renderGames;

--- a/src/style.css
+++ b/src/style.css
@@ -35,33 +35,68 @@ img {
   height: auto;
 }
 
-/* CSS code for Single Page App */
 body {
   display: flex;
   flex-direction: column;
   min-height: 100vh;
 }
 
+.btn {
+  cursor: pointer;
+  background-color: #fff;
+  border: 1px solid rgb(147, 147, 189);
+  padding: 5px 0;
+  font-size: 16px;
+  font-weight: 600;
+  border-radius: 5px;
+  color: rgb(80, 77, 77);
+}
+
+.btn:hover {
+  background-color: rgb(219, 217, 217);
+  color: blue;
+}
+
 #header {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  padding: 12px 5%;
+}
+
+.logo-container {
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  width: 30%;
+}
+
+.logo-container a {
+  align-self:flex-end;
+  padding: 5px 0;
 }
 
 .nav-menu {
-  width: 50%;
+  width: 65%;
+  align-self: flex-end;
 }
 
 .nav-list {
   display: flex;
   list-style: none;
-  justify-content: space-around;
+  justify-content: flex-end;
+  padding-right: 14%;
+}
+
+.nav-item + .nav-item {
+  margin-left: 36px;
 }
 
 .nav-link {
   text-decoration: none;
   font-size: 24px;
-  color: rgb(92, 91, 91);
+  color: #474747;
+  padding: 0;
 }
 
 .nav-link:hover {
@@ -184,7 +219,7 @@ input {
 }
 
 #main {
-  width: 90%;
+  width: 80%;
   margin: 16px auto;
 }
 
@@ -198,6 +233,7 @@ input {
 .game {
   display: flex;
   flex-direction: column;
+  justify-content: space-between;
   margin-bottom: 36px;
   width: 28%;
   padding: 5px;
@@ -222,6 +258,17 @@ input {
 .social-activities i {
   align-self: center;
   color: red;
+}
+
+.pagination-container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.btn-previous,
+.btn-next {
+  padding: 5px;
 }
 
 footer {

--- a/src/style.css
+++ b/src/style.css
@@ -52,7 +52,13 @@ body {
   color: rgb(80, 77, 77);
 }
 
-.btn:hover {
+.btn:disabled {
+  cursor: default;
+  background-color: rgb(209, 201, 201);
+  color: grey;
+}
+
+.btn:hover:not([disabled]) {
   background-color: rgb(219, 217, 217);
   color: blue;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -72,7 +72,7 @@ body {
 }
 
 .logo-container a {
-  align-self:flex-end;
+  align-self: flex-end;
   padding: 5px 0;
 }
 


### PR DESCRIPTION
## What this PR does:
  - Display the total number of games fetched from the Games API on the homepage as per issue #6 
  - Add pagination to display games list in the homepage page by page (

## To test it
  - clone the repository by running\
      `git clone https://github.com/gtekle/mmo-games.git`
  - navigate to the root folder\
      `cd mmo-games`
 - Install packages\
      `npm install`
  - Run application using `webpack-dev-server`\
      `npm start`

## Details
 - Added a pure function to get total number of games into GamesAPI class
 - Display total number of games fetched in the homepage
 - Refactor code into modules and components
 - Added styling to the list of games in the homepage and the header section
 - Add pagination to the list of games in the homepage
 - Fix linter errors